### PR TITLE
include repos by user role, rename parameters

### DIFF
--- a/api-renamed/index.js
+++ b/api-renamed/index.js
@@ -14,8 +14,8 @@ import { storeRequest } from "../src/common/database.js";
 export default async (req, res) => {
   const {
     username,
-    repos,
-    owners,
+    repo,
+    owner,
     hide,
     hide_title,
     hide_border,
@@ -72,8 +72,8 @@ export default async (req, res) => {
   const safePattern = /^[-\w\/.,]+$/;
   if (
     (username && !safePattern.test(username)) ||
-    (repos && !safePattern.test(repos)) ||
-    (owners && !safePattern.test(owners))
+    (repo && !safePattern.test(repo)) ||
+    (owner && !safePattern.test(owner))
   ) {
     return res.send(
       renderError(
@@ -93,9 +93,9 @@ export default async (req, res) => {
   try {
     await storeRequest(req);
     const showStats = parseArray(show);
-    const organizations = parseArray(owners);
-    let repositories = parseArray(repos);
-    repositories = repositories.map((repo) =>
+    const repoOwner = parseArray(owner);
+    let repository = parseArray(repo);
+    repository = repository.map((repo) =>
       repo.includes("/") ? repo : `${username}/${repo}`,
     );
 
@@ -103,18 +103,18 @@ export default async (req, res) => {
       username,
       parseBoolean(include_all_commits),
       parseArray(exclude_repo),
-      parseArray(role),
       showStats.includes("prs_merged") ||
         showStats.includes("prs_merged_percentage"),
       showStats.includes("discussions_started"),
       showStats.includes("discussions_answered"),
-      repositories,
-      organizations,
+      repository,
+      repoOwner,
       showStats.includes("prs_authored"),
       showStats.includes("prs_commented"),
       showStats.includes("prs_reviewed"),
       showStats.includes("issues_authored"),
       showStats.includes("issues_commented"),
+      parseArray(role),
     );
 
     let cacheSeconds = clampValue(
@@ -160,8 +160,8 @@ export default async (req, res) => {
           show: showStats,
         },
         username,
-        repositories,
-        organizations,
+        repository,
+        repoOwner,
       ),
     );
   } catch (err) {

--- a/api-renamed/index.js
+++ b/api-renamed/index.js
@@ -38,6 +38,7 @@ export default async (req, res) => {
     disable_animations,
     border_radius,
     number_format,
+    role,
     border_color,
     rank_icon,
     show,
@@ -102,6 +103,7 @@ export default async (req, res) => {
       username,
       parseBoolean(include_all_commits),
       parseArray(exclude_repo),
+      parseArray(role),
       showStats.includes("prs_merged") ||
         showStats.includes("prs_merged_percentage"),
       showStats.includes("discussions_started"),

--- a/api-renamed/top-langs.js
+++ b/api-renamed/top-langs.js
@@ -31,6 +31,7 @@ export default async (req, res) => {
     locale,
     border_radius,
     border_color,
+    role,
     disable_animations,
     hide_progress,
   } = req.query;
@@ -69,6 +70,7 @@ export default async (req, res) => {
       parseArray(exclude_repo),
       size_weight,
       count_weight,
+      parseArray(role),
     );
 
     let cacheSeconds = parseInt(

--- a/readme.md
+++ b/readme.md
@@ -178,7 +178,7 @@ To enable icons, you can pass `&show_icons=true` in the query param, like so:
 
 ### Filtering by repository and owner
 
-To compute your stats for only a specific repository, you can pass a query parameter `&repos=<user_or_organization>/<repository>`. You can also specify a comma-separated list of multiple repositories, e.g. `&repos=userA/repositoryA,organizationB/repositoryB`. And you can select all repositories owned by specific organizations or users by providing a comma-separated list of owners via the `owners` query parameter, e.g. `&owners=userA,organizationB,organizationC`. The `repos` and `owners` filters are supported by the following items: `commits` (when used with `&include_all_commits=true`), `prs_authored`, `prs_commented`, `prs_reviewed`, `issues_authored` and `issues_commented`. Note that most of these items are not displayed by default, but [you can enable them individually](#showing-additional-individual-stats).
+To compute your stats for only a specific repository, you can pass a query parameter `&repo=<user_or_organization>/<repository>`. You can also specify a comma-separated list of multiple repositories, e.g. `&repo=userA/repositoryA,organizationB/repositoryB`. And you can select all repositories owned by specific organizations or users by providing a comma-separated list of owners via the `owner` query parameter, e.g. `&owner=userA,organizationB,organizationC`. The `repo` and `owner` filters are supported by the following items: `commits` (when used with `&include_all_commits=true`), `prs_authored`, `prs_commented`, `prs_reviewed`, `issues_authored` and `issues_commented`. Note that most of these items are not displayed by default, but [you can enable them individually](#showing-additional-individual-stats).
 
 (Some of these mentioned items are similar to other items which are included by default, e.g. `issues_authored` is similar to `issues`. The difference is how these values are fetched - [via GraphQL or via REST API](https://github.com/anuraghazra/github-readme-stats/discussions/1770#number-of-commits-is-incorrect). The default items use GraphQL, but filtering by repository works better via REST API.)
 
@@ -384,14 +384,14 @@ If we don't support your language, please consider contributing! You can find mo
 | `include_all_commits` | Count total commits instead of just the current year commits. | boolean | `false` |
 | `line_height` | Sets the line height between text. | integer | `25` |
 | `exclude_repo` | Excludes specified repositories. Affects only the count for "Total Stars Earned". | string (comma-separated values) | `null` |
-| `repos` | Count only stats from the specified repositories. Affects only [certain items](#filtering-by-repository-and-owner). | string (comma-separated values) | `null` |
-| `owners` | Count only stats from the specified organizations or users. Affects only [certain items](#filtering-by-repository-and-owner). | string (comma-separated values) | `null` |
+| `repo` | Count only stats from the specified repositories. Affects only [certain items](#filtering-by-repository-and-owner). | string (comma-separated values) | `null` |
+| `owner` | Count only stats from the specified organizations or users. Affects only [certain items](#filtering-by-repository-and-owner). | string (comma-separated values) | `null` |
 | `custom_title` | Sets a custom title for the card. | string | `<username> GitHub Stats` |
 | `text_bold` | Uses bold text. | boolean | `true` |
 | `disable_animations` | Disables all animations in the card. | boolean | `false` |
 | `ring_color` | Color of the rank circle. | string (hex color) | `2f80ed` |
 | `number_format` | Switches between two available formats for displaying the card values: `short` (i.e. `6.6k`) and `long` (i.e. `6626`). | enum | `short` |
-| `show` | Shows [additional items](#showing-additional-individual-stats) on stats card (i.e. `reviews`, `discussions_started`, `discussions_answered`, `prs_merged` or `prs_merged_percentage`. And the following, which support the `repos` and `owners` filters: `prs_authored`, `prs_commented`, `prs_reviewed`, `issues_authored` or `issues_commented`). | string (comma-separated values) | `null` |
+| `show` | Shows [additional items](#showing-additional-individual-stats) on stats card (i.e. `reviews`, `discussions_started`, `discussions_answered`, `prs_merged` or `prs_merged_percentage`. And the following, which support the `repo` and `owner` filters: `prs_authored`, `prs_commented`, `prs_reviewed`, `issues_authored` or `issues_commented`). | string (comma-separated values) | `null` |
 
 > [!NOTE]\
 > When hide\_rank=`true`, the minimum card width is 270 px + the title length and padding.
@@ -678,11 +678,11 @@ Change the `?username=` value to your [WakaTime](https://wakatime.com) username.
 
 *   Showing stats for a specific repository
 
-![Anurag's GitHub stats for anuraghazra/github-readme-stats](https://github-readme-stats-phi-jet-58.vercel.app/api?username=anuraghazra\&repos=anuraghazra/github-readme-stats\&hide=prs,issues,stars,commits,contribs\&show=prs_authored,prs_commented,prs_reviewed,issues_authored,issues_commented\&hide_rank=true\&custom_title=Anurag%27s%20Stats%20for%20github-readme-stats\&card_width=370)
+![Anurag's GitHub stats for anuraghazra/github-readme-stats](https://github-readme-stats-phi-jet-58.vercel.app/api?username=anuraghazra\&repo=anuraghazra/github-readme-stats\&hide=prs,issues,stars,commits,contribs\&show=prs_authored,prs_commented,prs_reviewed,issues_authored,issues_commented\&hide_rank=true\&custom_title=Anurag%27s%20Stats%20for%20github-readme-stats\&card_width=370)
 
 *   Showing stats for a specific organization
 
-![Anurag's GitHub stats for razorpay](https://github-readme-stats-phi-jet-58.vercel.app/api?username=anuraghazra\&owners=razorpay\&hide=prs,issues,stars,commits,contribs\&show=prs_authored,prs_commented,prs_reviewed,issues_authored,issues_commented\&hide_rank=true\&custom_title=Anurag%27s%20Stats%20for%20razorpay\&card_width=370)
+![Anurag's GitHub stats for razorpay](https://github-readme-stats-phi-jet-58.vercel.app/api?username=anuraghazra\&owner=razorpay\&hide=prs,issues,stars,commits,contribs\&show=prs_authored,prs_commented,prs_reviewed,issues_authored,issues_commented\&hide_rank=true\&custom_title=Anurag%27s%20Stats%20for%20razorpay\&card_width=370)
 
 *   Showing icons
 

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -214,8 +214,8 @@ const renderStatsCard = (
   stats,
   options = {},
   username,
-  repos = [],
-  owners = [],
+  repo = [],
+  owner = [],
 ) => {
   const {
     name,
@@ -360,7 +360,7 @@ const renderStatsCard = (
     };
   }
 
-  let repoFilter = encodeURIComponent(buildSearchFilter(repos, owners));
+  let repoFilter = encodeURIComponent(buildSearchFilter(repo, owner));
   if (show.includes("prs_authored")) {
     STATS.prs_authored = {
       icon: icons.prs,

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -4,6 +4,8 @@ import toEmoji from "emoji-name-map";
 import wrap from "word-wrap";
 import { themes } from "../../themes/index.js";
 
+const OWNER_AFFILIATIONS = ["OWNER", "COLLABORATOR", "ORGANIZATION_MEMBER"];
+
 const TRY_AGAIN_LATER = "Please try again later";
 
 const SECONDARY_ERROR_MESSAGES = {
@@ -15,6 +17,9 @@ const SECONDARY_ERROR_MESSAGES = {
   GRAPHQL_ERROR: TRY_AGAIN_LATER,
   GITHUB_REST_API_ERROR: TRY_AGAIN_LATER,
   WAKATIME_USER_NOT_FOUND: "Make sure you have a public WakaTime profile",
+  INVALID_AFFILIATION: `Invalid owner affiliations. Valid values are: ${OWNER_AFFILIATIONS.join(
+    ", ",
+  )}`,
 };
 
 /**
@@ -37,6 +42,7 @@ class CustomError extends Error {
   static GRAPHQL_ERROR = "GRAPHQL_ERROR";
   static GITHUB_REST_API_ERROR = "GITHUB_REST_API_ERROR";
   static WAKATIME_ERROR = "WAKATIME_ERROR";
+  static INVALID_AFFILIATION = "INVALID_AFFILIATION";
 }
 
 /**
@@ -598,6 +604,36 @@ const parseEmojis = (str) => {
     return toEmoji.get(emoji) || "";
   });
 };
+/**
+ * Parse owner affiliations.
+ *
+ * @param {string[]} affiliations
+ * @returns {string[]} Parsed affiliations.
+ *
+ * @throws {CustomError} If affiliations contains invalid values.
+ */
+const parseOwnerAffiliations = (affiliations) => {
+  // Set default value for ownerAffiliations.
+  // NOTE: Done here since parseArray() will always return an empty array even nothing
+  //was specified.
+  affiliations =
+    affiliations && affiliations.length > 0
+      ? affiliations.map((affiliation) => affiliation.toUpperCase())
+      : ["OWNER"];
+
+  // Check if ownerAffiliations contains valid values.
+  if (
+    affiliations.some(
+      (affiliation) => !OWNER_AFFILIATIONS.includes(affiliation),
+    )
+  ) {
+    throw new CustomError(
+      "Invalid query parameter",
+      CustomError.INVALID_AFFILIATION,
+    );
+  }
+  return affiliations;
+};
 
 /**
  * Get diff in minutes between two dates.
@@ -633,11 +669,13 @@ export {
   wrapTextMultiline,
   logger,
   CONSTANTS,
+  OWNER_AFFILIATIONS,
   CustomError,
   MissingParamError,
   measureText,
   lowercaseTrim,
   chunkArray,
   parseEmojis,
+  parseOwnerAffiliations,
   dateDiff,
 };

--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -62,9 +62,9 @@ const fetcher = (variables, token) => {
  *
  * @param {string} username GitHub username.
  * @param {string[]} exclude_repo List of repositories to exclude. Default: [].
- * @param {string[]} ownerAffiliations The owner affiliations to filter by. Default: OWNER.
  * @param {number} size_weight Weightage to be given to size.
  * @param {number} count_weight Weightage to be given to count.
+ * @param {string[]} ownerAffiliations The owner affiliations to filter by. Default: OWNER.
  * @returns {Promise<TopLangData>} Top languages data.
  */
 const fetchTopLanguages = async (

--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -6,6 +6,7 @@ import {
   MissingParamError,
   request,
   wrapTextMultiline,
+  parseOwnerAffiliations,
 } from "../common/utils.js";
 
 /**
@@ -24,10 +25,10 @@ const fetcher = (variables, token) => {
   return request(
     {
       query: `
-      query userInfo($login: String!) {
+      query userInfo($login: String!, $ownerAffiliations: [RepositoryAffiliation]) {
         user(login: $login) {
-          # fetch only owner repos & not forks
-          repositories(ownerAffiliations: OWNER, isFork: false, first: 100) {
+          # do not fetch forks
+          repositories(ownerAffiliations: $ownerAffiliations, isFork: false, first: 100) {
             nodes {
               name
               languages(first: 10, orderBy: {field: SIZE, direction: DESC}) {
@@ -60,7 +61,8 @@ const fetcher = (variables, token) => {
  * Fetch top languages for a given username.
  *
  * @param {string} username GitHub username.
- * @param {string[]} exclude_repo List of repositories to exclude.
+ * @param {string[]} exclude_repo List of repositories to exclude. Default: [].
+ * @param {string[]} ownerAffiliations The owner affiliations to filter by. Default: OWNER.
  * @param {number} size_weight Weightage to be given to size.
  * @param {number} count_weight Weightage to be given to count.
  * @returns {Promise<TopLangData>} Top languages data.
@@ -70,12 +72,14 @@ const fetchTopLanguages = async (
   exclude_repo = [],
   size_weight = 1,
   count_weight = 0,
+  ownerAffiliations = [],
 ) => {
   if (!username) {
     throw new MissingParamError(["username"]);
   }
+  ownerAffiliations = parseOwnerAffiliations(ownerAffiliations);
 
-  const res = await retryer(fetcher, { login: username });
+  const res = await retryer(fetcher, { login: username, ownerAffiliations });
 
   if (res.data.errors) {
     logger.error(res.data.errors);


### PR DESCRIPTION
This PR adds the "role" parameter to include repositories where the user is [owner/collaborator/organization_member](https://docs.github.com/en/graphql/reference/enums#repositoryaffiliation). This PR also renames parameters "owners" to "owner" and "repos" to "repo", to be in line with the parameter "exclude_repo".

The "role" parameter is based on work by `@developStorm` and `@rickstaa`.